### PR TITLE
Only send messages in specified channel to Minecraft

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,8 +4,8 @@
 var Discord = require("discord.js");
 var Rcon = require("rcon");
 var express = require("express");
-var app = express(); 
-var http = require("http").Server(app); 
+var app = express();
+var http = require("http").Server(app);
 var c = require("./config.json");
 var debug = c.DEBUG;
 var shulker = new Discord.Client();
@@ -13,9 +13,9 @@ var shulker = new Discord.Client();
 var client = new Rcon(c.MINECRAFT_SERVER_RCON_IP, c.MINECRAFT_SERVER_RCON_PORT, c.MINECRAFT_SERVER_RCON_PASSWORD);
 
 client.on("auth", function() {
-    console.log("[INFO] Authenticated with "+c.MINECRAFT_SERVER_RCON_IP+":"+c.MINECRAFT_SERVER_RCON_PORT);
+    console.log("[INFO] Authenticated with " + c.MINECRAFT_SERVER_RCON_IP + ":" + c.MINECRAFT_SERVER_RCON_PORT);
 }).on("response", function(str) {
-    if(debug && str) {
+    if (debug && str) {
         console.log("[DEBUG] Got response: " + str);
     }
 }).on("end", function() {
@@ -25,42 +25,44 @@ client.on("auth", function() {
 client.connect();
 
 app.use(function(request, response, next) {
-  request.rawBody = "";
-  request.setEncoding("utf8");
+    request.rawBody = "";
+    request.setEncoding("utf8");
 
-  request.on("data", function(chunk) { 
-      request.rawBody += chunk;
-  });
+    request.on("data", function(chunk) {
+        request.rawBody += chunk;
+    });
 
-  request.on("end", function() {
-      next();
-  });
+    request.on("end", function() {
+        next();
+    });
 });
 
 shulker.on("ready", function() {
-    var channel = shulker.channels.get("name", c.DISCORD_CHANNEL).id; 
-    app.post(c.WEBHOOK, function(request, response){
+    var channel = shulker.channels.get("name", c.DISCORD_CHANNEL).id;
+    app.post(c.WEBHOOK, function(request, response) {
         var body = request.rawBody;
-        console.log("[INFO] Recieved "+body);
+        console.log("[INFO] Recieved " + body);
         var re = new RegExp(c.REGEX_MATCH_CHAT_MC);
         var ignored = new RegExp(c.REGEX_IGNORED_CHAT);
-        if(!ignored.test(body)) {
+        if (!ignored.test(body)) {
             var bodymatch = body.match(re);
-            if(debug) {
-                console.log("[DEBUG] Username: "+bodymatch[1]);
-                console.log("[DEBUG] Text: "+bodymatch[2]);
+            if (debug) {
+                console.log("[DEBUG] Username: " + bodymatch[1]);
+                console.log("[DEBUG] Text: " + bodymatch[2]);
             }
-            var message = "**"+bodymatch[1]+"**: "+bodymatch[2];
+            var message = "**" + bodymatch[1] + "**: " + bodymatch[2];
             shulker.channels.get("id", channel).sendMessage(message);
         }
         response.send("");
     });
 });
 
-shulker.on("message", function (message) {
-    if(message.author.id !== shulker.user.id) {
-        var data = { text: "<"+message.author.username+"> "+message.content };
-        client.send('tellraw @a ["",'+JSON.stringify(data)+']');
+shulker.on("message", function(message) {
+    if (message.author.id !== shulker.user.id) {
+        var data = {
+            text: "<" + message.author.username + "> " + message.content
+        };
+        client.send('tellraw @a ["",' + JSON.stringify(data) + ']');
     }
 });
 
@@ -69,11 +71,11 @@ shulker.login(c.DISCORD_EMAIL, c.DISCORD_PASSWORD);
 var ipaddress = process.env.OPENSHIFT_NODEJS_IP || process.env.IP || "127.0.0.1";
 var serverport = process.env.OPENSHIFT_NODEJS_PORT || process.env.PORT || c.PORT;
 if (process.env.OPENSHIFT_NODEJS_IP !== undefined) {
-    http.listen( serverport, ipaddress, function() {
+    http.listen(serverport, ipaddress, function() {
         console.log("[INFO] Bot listening on *:" + serverport);
     });
 } else {
-    http.listen( serverport, function() {
+    http.listen(serverport, function() {
         console.log("[INFO] Bot listening on *:" + c.PORT);
     });
 }

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 /*jslint bitwise: true, node: true */
+'use strict';
 
 var Discord = require("discord.js");
 var Rcon = require("rcon");
@@ -39,17 +40,17 @@ app.use(function(request, response, next) {
 shulker.on("ready", function() {
     var channel = shulker.channels.get("name", c.DISCORD_CHANNEL).id; 
     app.post(c.WEBHOOK, function(request, response){
-        body = request.rawBody;
-        console.log("[INFO] Recieved "+body);  
-        re = new RegExp(c.REGEX_MATCH_CHAT_MC);
-        ignored = new RegExp(c.REGEX_IGNORED_CHAT);
+        var body = request.rawBody;
+        console.log("[INFO] Recieved "+body);
+        var re = new RegExp(c.REGEX_MATCH_CHAT_MC);
+        var ignored = new RegExp(c.REGEX_IGNORED_CHAT);
         if(!ignored.test(body)) {
-            bodymatch = body.match(re);
+            var bodymatch = body.match(re);
             if(debug) {
                 console.log("[DEBUG] Username: "+bodymatch[1]);
                 console.log("[DEBUG] Text: "+bodymatch[2]);
             }
-            message = "**"+bodymatch[1]+"**: "+bodymatch[2];
+            var message = "**"+bodymatch[1]+"**: "+bodymatch[2];
             shulker.channels.get("id", channel).sendMessage(message);
         }
         response.send("");
@@ -58,7 +59,7 @@ shulker.on("ready", function() {
 
 shulker.on("message", function (message) {
     if(message.author.id !== shulker.user.id) {
-        data = { text: "<"+message.author.username+"> "+message.content };
+        var data = { text: "<"+message.author.username+"> "+message.content };
         client.send('tellraw @a ["",'+JSON.stringify(data)+']');
     }
 });

--- a/index.js
+++ b/index.js
@@ -58,11 +58,13 @@ shulker.on("ready", function() {
 });
 
 shulker.on("message", function(message) {
-    if (message.author.id !== shulker.user.id) {
-        var data = {
-            text: "<" + message.author.username + "> " + message.content
-        };
-        client.send('tellraw @a ["",' + JSON.stringify(data) + ']');
+    if (message.channel.id === shulker.channels.get("name", c.DISCORD_CHANNEL).id) {
+        if (message.author.id !== shulker.user.id) {
+            var data = {
+                text: "<" + message.author.username + "> " + message.content
+            };
+            client.send('tellraw @a ["",' + JSON.stringify(data) + ']');
+        }
     }
 });
 


### PR DESCRIPTION
Before, Discord messages from all channels were being sent to Minecraft. This commit makes it so that only messages in the channel that Shulker is sending to (by default `#general`) are forwarded to Minecraft.