### PR TITLE
Use token instead of email and password

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,7 @@ You can also easily Deploy to Heroku or Bluemix.
 ```js
 {
     "PORT": 8000, /* Port you want to run the webserver for the hook on */
-    "DISCORD_EMAIL": "example@example.com", /* discord email */
-    "DISCORD_PASSWORD": "password123", /* discord password */
+    "DISCORD_TOKEN": "TOKEN_HERE", /* discord token */
     "DISCORD_CHANNEL": "general", /* channel for discord bot */
     "MINECRAFT_SERVER_RCON_IP": "example.com", /* minecraft server ip (make sure you have enabled rcon) */
     "MINECRAFT_SERVER_RCON_PORT": <1-65535>, /* minecraft server rcon port */
@@ -52,6 +51,14 @@ You can also easily Deploy to Heroku or Bluemix.
 }
 ```
 
+### Application token
+
+1. Head over to the [applications page](https://discordapp.com/developers/applications/me#top) and create a new application
+2. Give your bot a name and hit "Create application"
+3. Click "Create a Bot User"
+4. After that, head over to `https://discordapp.com/oauth2/authorize?&client_id=CLIENT_ID&scope=bot` replacing `CLIENT_ID` with Client/Application ID under "App Details"
+5. Add your bot to a server and go back to the applications page
+6. Click "Reveal token" and copy the token to your config.json file
 
 ## Tests
 Run the tests with:

--- a/config.json
+++ b/config.json
@@ -1,7 +1,6 @@
 {
     "PORT": 8000,
-    "DISCORD_EMAIL": "example@example.com",
-    "DISCORD_PASSWORD": "password123",
+    "DISCORD_TOKEN": "TOKEN_HERE",
     "DISCORD_CHANNEL": "general",
     "MINECRAFT_SERVER_RCON_IP": "example.com",
     "MINECRAFT_SERVER_RCON_PORT": 25575,

--- a/index.js
+++ b/index.js
@@ -50,7 +50,7 @@ shulker.on("ready", function() {
     var channel = shulker.channels.get("name", c.DISCORD_CHANNEL).id;
     app.post(c.WEBHOOK, function(request, response) {
         var body = request.rawBody;
-        console.log("[INFO] Recieved " + body);
+        console.log("[INFO] Received " + body);
         var re = new RegExp(c.REGEX_MATCH_CHAT_MC);
         var ignored = new RegExp(c.REGEX_IGNORED_CHAT);
         if (!ignored.test(body)) {
@@ -77,7 +77,7 @@ shulker.on("message", function(message) {
     }
 });
 
-shulker.login(c.DISCORD_EMAIL, c.DISCORD_PASSWORD);
+shulker.loginWithToken(c.DISCORD_TOKEN);
 
 var ipaddress = process.env.OPENSHIFT_NODEJS_IP || process.env.IP || "127.0.0.1";
 var serverport = process.env.OPENSHIFT_NODEJS_PORT || process.env.PORT || c.PORT;

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "homepage": "https://github.com/destruc7i0n/shulker#readme",
   "dependencies": {
-    "discord.js": "^6.1.0",
+    "discord.js": "^7.0.1",
     "express": "^4.13.3",
     "rcon": "^1.0.1"
   },


### PR DESCRIPTION
For quite some time Discord does not want you to use an email and password for your bot but rather supports applications. They have a lot of benefits.

They authenticate using a token system. Read more [here](https://discordapp.com/developers/docs/topics/oauth2#bot-vs-user-accounts) and [here](https://discordapp.com/developers/docs/intro#applications-aka-apps).

Changes proposed in this pull request:

- Update discord.js dependency
- Fix typo
- Use token instead of email and password for authentication