### PR TITLE
Better regex in case of > in message

### DIFF
--- a/config.json
+++ b/config.json
@@ -6,7 +6,7 @@
     "MINECRAFT_SERVER_RCON_PORT": 25575,
     "MINECRAFT_SERVER_RCON_PASSWORD": "password",
     "WEBHOOK": "/minecraft/hook",
-    "REGEX_MATCH_CHAT_MC": "\\[Server thread/INFO\\]: <(.*)> (.*)",
+    "REGEX_MATCH_CHAT_MC": "\\[Server thread/INFO\\]: <([^>]]*)> (.*)",
     "REGEX_IGNORED_CHAT": "packets too frequently",
     "RCON_RECONNECT_DELAY": 10,
     "DEBUG": false

--- a/config.json
+++ b/config.json
@@ -6,7 +6,7 @@
     "MINECRAFT_SERVER_RCON_PORT": 25575,
     "MINECRAFT_SERVER_RCON_PASSWORD": "password",
     "WEBHOOK": "/minecraft/hook",
-    "REGEX_MATCH_CHAT_MC": "\\[Server thread/INFO\\]: <([^>]]*)> (.*)",
+    "REGEX_MATCH_CHAT_MC": "\\[Server thread/INFO\\]: <([^>]*)> (.*)",
     "REGEX_IGNORED_CHAT": "packets too frequently",
     "RCON_RECONNECT_DELAY": 10,
     "DEBUG": false


### PR DESCRIPTION
If someone uses a '>' in their message, the previous regex will screw up. This regex will contain the first capturing group to everything up to the first '>' character!