### PR TITLE
Ability to display when player joins/leaves or earns an achievement or dies in Discord

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ $ yarn
 $ yarn start
 ```
 
-If you are running this locally, check the `IS_LOCAL_FILE` flag and related options below. Otherwise, perform the following command: 
+If you are running this locally, check the `IS_LOCAL_FILE` flag and related options below. Otherwise, perform the following command:
 On your server hosting (in a screen/tmux session or background process, make sure to replace your `YOUR_URL` with whatever URL you're using (`localhost:8000` if running on the same server and default config) and `PATH_TO_MINECRAFT_SERVER_INSTALL` with the path to the Minecraft server installation, such as `/usr/home/minecraft_server/`):
 
 ``` sh
@@ -43,26 +43,29 @@ You can also easily Deploy to Heroku and the like, just be sure to edit `YOUR_UR
 ```js
 {
     "PORT": 8000, /* Port you want to run the webserver for the hook on */
-    
+
     "USE_WEBHOOKS": true, /* If you want to use snazzy webhooks */
     "WEBHOOK_URL": "DISCORD_WEBHOOK_URL_HERE", /* Be sure to create a webhook in the channel settings and place it here! */
     "DISCORD_TOKEN": "<12345>", /* Discord bot token. [Click here](https://discordapp.com/developers/applications/me) to create you application and add a bot to it. */
     "DISCORD_CHANNEL_ID": "<channel>", /* Discord channel ID for for the discord bot. Enable developer mode in your Discord client, then right click channel and select "Copy ID". */
     "DISCORD_MESSAGE_TEMPLATE": "`%username%`:%message%", /* Message template to display in Discord */
-    
+
     "MINECRAFT_SERVER_RCON_IP": "127.0.0.1", /* Minecraft server IP (make sure you have enabled rcon) */
     "MINECRAFT_SERVER_RCON_PORT": <1-65535>, /* Minecraft server rcon port */
     "MINECRAFT_SERVER_RCON_PASSWORD": "<your password>", /* Minecraft server rcon password */
     "MINECRAFT_TELLRAW_TEMPLATE": "[{\"color\": \"white\", \"text\": \"<%username%> %message%\"}]", /* Tellraw template to display in Minecraft */
-    
+
     "IS_LOCAL_FILE": false, /* should tail the local file, may be a little buggy. please report any you find */
     "LOCAL_FILE_PATH": "/usr/home/minecraft_server/logs/latest.log", /* the path to the local file if specified */
     "ALLOW_USER_MENTIONS": false, /* should replace @mentions with the mention in discord */
-    
+
     "WEBHOOK": "/minecraft/hook", /* Web hook, where to send the log to */
     "REGEX_MATCH_CHAT_MC": "\\[Server thread/INFO\\]: <(.*)> (.*)", /* What to match for chat (best to leave as default) */
     "REGEX_IGNORED_CHAT": "packets too frequently", /* What to ignore, you can put any regex for swear words for example and it will  be ignored */
-    "DEBUG": false /* Dev debugging */
+    "DEBUG": false, /* Dev debugging */
+
+    "SERVER_NAME" : "Shulker", /* The username used when displaying any server information in chat, e.g., Server - Shulker : Server message here*/
+    "SHOW_PLAYER_CONN_STAT" : false /* Shows player connection status in chat, e.g., Server - Shulker : TheMachine joined the game */
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,8 @@ You can also easily Deploy to Heroku and the like, just be sure to edit `YOUR_UR
     "DEBUG": false, /* Dev debugging */
 
     "SERVER_NAME" : "Shulker", /* The username used when displaying any server information in chat, e.g., Server - Shulker : Server message here*/
-    "SHOW_PLAYER_CONN_STAT" : false /* Shows player connection status in chat, e.g., Server - Shulker : TheMachine joined the game */
+    "SHOW_PLAYER_CONN_STAT" : false, /* Shows player connection status in chat, e.g., Server - Shulker : TheMachine joined the game */
+    "SHOW_PLAYER_ACHV" : false /* Shows when players earn achievements in chat, e.g., Server - Shulker : TheMachine has earned the achievement [MEME - Machine] */
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,9 @@ You can also easily Deploy to Heroku and the like, just be sure to edit `YOUR_UR
 
     "SERVER_NAME" : "Shulker", /* The username used when displaying any server information in chat, e.g., Server - Shulker : Server message here*/
     "SHOW_PLAYER_CONN_STAT" : false, /* Shows player connection status in chat, e.g., Server - Shulker : TheMachine joined the game */
-    "SHOW_PLAYER_ACHV" : false /* Shows when players earn achievements in chat, e.g., Server - Shulker : TheMachine has earned the achievement [MEME - Machine] */
+    "SHOW_PLAYER_ACHV" : false, /* Shows when players earn achievements in chat, e.g., Server - Shulker : TheMachine has earned the achievement [MEME - Machine] */
+    "SHOW_PLAYER_DEATH" : false, /* Shows when players die in chat, e.g., Server - Shulker : TheMachine was blown up by creeper */
+    "DEATH_KEY_WORDS" : ["shot", "fell", "etc".] /* Key words to look for when trying to identify a death message. (As of 3/11/2019 this list is up to date) */
 }
 ```
 

--- a/config.json
+++ b/config.json
@@ -21,5 +21,8 @@
     "REGEX_MATCH_CHAT_MC": "\\[Server thread/INFO\\]: <([^>]*)> (.*)",
     "REGEX_IGNORED_CHAT": "packets too frequently",
     "RCON_RECONNECT_DELAY": 10,
-    "DEBUG": false
+    "DEBUG": false,
+
+    "SHOW_PLAYER_CONN_STAT" : false,
+    "SERVER_NAME" : "Shulker"
 }

--- a/config.json
+++ b/config.json
@@ -25,5 +25,7 @@
 
     "SERVER_NAME" : "Shulker",
     "SHOW_PLAYER_CONN_STAT" : false,
-    "SHOW_PLAYER_ACHV" : false
+    "SHOW_PLAYER_ACHV" : false,
+    "SHOW_PLAYER_DEATH" : false,
+    "DEATH_KEY_WORDS" : ["shot", "fell", "death", "died", "doomed", "pummeled", "removed", "didn't want", "withered", "squashed", "flames", "burnt", "walked into", "bang", "roasted", "squished", "drowned", "killed", "slain", "blown", "blew", "suffocated", "struck", "lava", "impaled", "speared", "fireballed", "finished", "kinetic"]
 }

--- a/config.json
+++ b/config.json
@@ -23,6 +23,7 @@
     "RCON_RECONNECT_DELAY": 10,
     "DEBUG": false,
 
+    "SERVER_NAME" : "Shulker",
     "SHOW_PLAYER_CONN_STAT" : false,
-    "SERVER_NAME" : "Shulker"
+    "SHOW_PLAYER_ACHV" : false
 }

--- a/index.js
+++ b/index.js
@@ -171,11 +171,23 @@ function parseLogLine(data){
     return(data)
   }
 
-  // Otherwise return blank
-  else {
-    data = ''
-    return(data)
+  // Check if the data is a player death (if enabled)
+  else if (c.SHOW_PLAYER_DEATH){
+    // Check for a match of any DEATH_KEY_WORDS
+    for (var index = 0; index < c.DEATH_KEY_WORDS.length; index++){
+      if (data.indexOf(c.DEATH_KEY_WORDS[index]) !== -1){
+        if (debug){
+          console.log('[DEBUG] a player died. Matched key word \"' + c.DEATH_KEY_WORDS[index] + "\"");
+        }
+        data = convertToServerMessage(data)
+        return(data)
+      }
+    }
   }
+
+  // Otherwise return blank
+  data = ''
+  return(data)
 }
 
 function watch (callback) {

--- a/index.js
+++ b/index.js
@@ -156,7 +156,7 @@ function parseLogLine(data){
   // Check if the data is a player joining or leaving (if enabled)
   else if (c.SHOW_PLAYER_CONN_STAT && (data.indexOf('left the game') !== -1 || data.indexOf('joined the game') !== -1)){
     if (debug){
-      console.log('[Debug]: a player\'s connection status changed')
+      console.log('[Debug]: A player\'s connection status changed')
     }
     data = convertToServerMessage(data)
     return(data)

--- a/index.js
+++ b/index.js
@@ -177,7 +177,7 @@ function parseLogLine(data){
     for (var index = 0; index < c.DEATH_KEY_WORDS.length; index++){
       if (data.indexOf(c.DEATH_KEY_WORDS[index]) !== -1){
         if (debug){
-          console.log('[DEBUG] a player died. Matched key word \"' + c.DEATH_KEY_WORDS[index] + "\"");
+          console.log('[DEBUG] A player died. Matched key word \"' + c.DEATH_KEY_WORDS[index] + "\"");
         }
         data = convertToServerMessage(data)
         return(data)

--- a/index.js
+++ b/index.js
@@ -151,6 +151,15 @@ function watch (callback) {
         // Change player username to server name
     	  data = data.replace(username, "<" + c.SERVER_NAME + " - Server> " + username)
     	  callback(data)
+      } else if (c.SHOW_PLAYER_ACHV && data.indexOf('has just earned the achievement') !== -1){
+        // Get username of player that earned the achievement
+    	  var username = getWordAt(data, 33)
+        if (debug){
+          console.log('[Debug]', username + ' has earned an achievement')
+        }
+        // Change player username to server name
+    	  data = data.replace(username, "<" + c.SERVER_NAME + " - Server> " + username)
+    	  callback(data)
       }
     })
   } else {


### PR DESCRIPTION
### **Displaying when players join/leave the server**
This feature is mainly to make it easy to see when people join. In my experience, when other on my server see that other players have joined, it causes them to hop on as well.  It looks OK without web-hooks but it looks way better with them.

Example:
![image](https://user-images.githubusercontent.com/31785616/54134623-afaae200-43ee-11e9-9769-09f1a2e5cb0b.png)

Debug Output:
![image](https://user-images.githubusercontent.com/31785616/54134782-eda80600-43ee-11e9-9910-3549824d4ae9.png)



### **Displaying when players earn and achievement**
This simply shows when any player earns an achievement.

Example:
![image](https://user-images.githubusercontent.com/31785616/54134441-5cd12a80-43ee-11e9-9ea7-28edc8ca6474.png)

Debug Output:
![image](https://user-images.githubusercontent.com/31785616/54134490-73778180-43ee-11e9-9aa1-0063a4303167.png)



### **Displaying when players die**
This simply shows when a player dies in chat, I went through every possible death message in Minecraft and condensed them down into the DEATH_KEY_WORDS list in the config file.

Example:
![image](https://user-images.githubusercontent.com/31785616/54134101-b1c07100-43ed-11e9-8f8e-090424f68407.png)

Debug Output:
![image](https://user-images.githubusercontent.com/31785616/54134224-f4824900-43ed-11e9-847a-5eda29be9fc2.png)



