### PR TITLE
Allow more complex tellraw templates

### DIFF
--- a/src/Discord.ts
+++ b/src/Discord.ts
@@ -140,7 +140,7 @@ class Discord {
     }
 
     return this.config.MINECRAFT_TELLRAW_TEMPLATE
-      // new RegExp('%example%', 'g') will replace every instance of %example% inthe TELLRAW_TEMPLATE
+      // new RegExp('%example%', 'g') will replace every instance of %example% in the TELLRAW_TEMPLATE
       .replace(new RegExp('%username%', 'g'), variables.username)
       .replace(new RegExp('%discriminator%', 'g'), variables.discriminator)
       .replace(new RegExp('%message%', 'g'), variables.text)

--- a/src/Discord.ts
+++ b/src/Discord.ts
@@ -140,9 +140,10 @@ class Discord {
     }
 
     return this.config.MINECRAFT_TELLRAW_TEMPLATE
-      .replace('%username%', variables.username)
-      .replace('%discriminator%', variables.discriminator)
-      .replace('%message%', variables.text)
+      // new RegExp('%example%', 'g') will replace every instance of %example% inthe TELLRAW_TEMPLATE
+      .replace(new RegExp('%username%', 'g'), variables.username)
+      .replace(new RegExp('%discriminator%', 'g'), variables.discriminator)
+      .replace(new RegExp('%message%', 'g'), variables.text)
   }
 
   private replaceDiscordMentions(message: string): string {

--- a/src/Discord.ts
+++ b/src/Discord.ts
@@ -140,10 +140,10 @@ class Discord {
     }
 
     return this.config.MINECRAFT_TELLRAW_TEMPLATE
-      // new RegExp('%example%', 'g') will replace every instance of %example% in the TELLRAW_TEMPLATE
-      .replace(new RegExp('%username%', 'g'), variables.username)
-      .replace(new RegExp('%discriminator%', 'g'), variables.discriminator)
-      .replace(new RegExp('%message%', 'g'), variables.text)
+      // .replace(/oldstring/g, newstring) will replace all instances of oldstring with newstring 
+      .replace(/%username%/g, variables.username)
+      .replace(/%discriminator%/g, variables.discriminator)
+      .replace(/%message%/g, variables.text)
   }
 
   private replaceDiscordMentions(message: string): string {


### PR DESCRIPTION
I wanted to do a more complex tellraw where I used a variable more than once.  However, only the first instance of a variable would be replaced.  The changes I made replace ALL instances of each variable in a given MINECRAFT_TELLRAW_TEMPLATE 

The example below is where I had to use this.  The blue text when shift-clicked in game will populate the Minecraft chat prompt with discordusername#delimiter so the Minecraft user does not have to type out an entire desired discord user's username and delimiter manually to mention them.

**This is what it looks like in game.** 
![image](https://user-images.githubusercontent.com/31785616/82634174-1d45c700-9bcb-11ea-9da7-e549065dfc74.png)
**and in discord**
![image](https://user-images.githubusercontent.com/31785616/82634492-cbea0780-9bcb-11ea-8fd3-9c0efe0bb6a4.png)

I can make a pull request where I add this message template in the README as an example if you wish.  It looks pretty good and it is pretty functional.