### PR TITLE
Improved regex for user mentions and TELLRAW

### DIFF
--- a/src/Discord.ts
+++ b/src/Discord.ts
@@ -140,9 +140,9 @@ class Discord {
     }
 
     return this.config.MINECRAFT_TELLRAW_TEMPLATE
-      .replace('%username%', variables.username)
-      .replace('%discriminator%', variables.discriminator)
-      .replace('%message%', variables.text)
+      .replace(/%username%/g, variables.username)
+      .replace(/%discriminator%/g, variables.discriminator)
+      .replace(/%message%/g, variables.text)
   }
 
   private replaceDiscordMentions(message: string): string {

--- a/src/Discord.ts
+++ b/src/Discord.ts
@@ -146,7 +146,7 @@ class Discord {
   }
 
   private replaceDiscordMentions(message: string): string {
-    const possibleMentions = message.match(/@(\S+)/gim)
+    const possibleMentions = message.match(/@*.*#[0-9]{4}/gim)
     if (possibleMentions) {
       for (let mention of possibleMentions) {
         const mentionParts = mention.split('#')


### PR DESCRIPTION
**Tested on 2 x 24/7 servers**
* 1.15.2 Vanilla
* FTB-Beyond 1.11.0

**Does not conflict with pull request #55** 

**Details:**
- I improved the regex for user mention detection to work with Discord users with spaces in their names. It now searches for any string that starts with an @ symbol and ends with a # sign with 4 numbers after it. /@*.*#[0-9]{4}/

Verified at https://regexr.com/ and in live server
![image](https://user-images.githubusercontent.com/31785616/82744510-56e31300-9d2e-11ea-8113-166c7e01fe9c.png)

- I wanted to do a more complex tellraw where I used a variable more than once. However, only the first instance of a variable would be replaced. The changes I made replace ALL instances of each variable in a given MINECRAFT_TELLRAW_TEMPLATE

The example below is where I had to use this. The blue text when shift-clicked in game will populate the Minecraft chat prompt with discordusername#delimiter so the Minecraft user does not have to type out an entire desired discord user's username and delimiter manually to mention them.

Here is the TELLRAW used to test this
"MINECRAFT_TELLRAW_TEMPLATE": "[\"\",{\"text\":\"Discord \",\"bold\":true,\"color\":\"blue\"},{\"text\":\"<\"},{\"text\":\"%username%\",\"color\":\"aqua\",\"insertion\":\"@%username%#%discriminator% \"},{\"text\":\"> %message%\"}]",

This is what it looks like in game.
![image](https://user-images.githubusercontent.com/31785616/82742985-7a4f9300-9d19-11ea-9884-56dd580a7328.png)

and in discord
![image](https://user-images.githubusercontent.com/31785616/82742981-73288500-9d19-11ea-9fd9-5661d6ea9354.png)

If you like my template and want to add it to the repo as the default or as a suggestion in the readme, let me know and i'll add it to this pull request.