### PR TITLE
Added ability to append The number of players online to server username

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,8 +86,8 @@ You can also easily Deploy to Heroku and the like, just be sure to edit `YOUR_UR
 
     "SERVER_IMAGE": "", /* Image for the server when sending such messages (if enabled below). Only for WebHooks. */
     "SERVER_NAME": "Shulker", /* The username used when displaying any server information in chat, e.g., Shulker - Server : Server message here*/
-    "PLAYERCOUNT_IN_SERVERNAME": false, /* Will add the number of players currently in the server to any server messages e.g., Shulker - Server (1 online) : Server message here*/
-    "PLAYERCOUNT": 0, /* For most cases you can leave this at 0 but if you are starting Shulker when there are already players in the server set this to the current number of players online*/
+    "PLAYERCOUNT_IN_SERVERNAME": false, /* Will add the number of players currently in the server to the server username e.g., Shulker - Server - 1 online : Server message here*/
+    "PLAYERCOUNT": 0, /* For most cases you can leave this at 0 but if you are starting Shulker when there are already players in the server set this to the current number of players online if this is incorrectly set it will tautomatically fix itself once the server hits 0 players*/
     "SHOW_PLAYER_CONN_STAT": false, /* Shows player connection status in chat, e.g., Server - Shulker : TheMachine joined the game */
     "SHOW_PLAYER_ADVANCEMENT": false, /* Shows when players earn advancements in chat, e.g., Server - Shulker : TheMachine has made the advacement [MEME - Machine] */
     "SHOW_PLAYER_DEATH": false, /* Shows when players die in chat, e.g., Server - Shulker : TheMachine was blown up by creeper */

--- a/README.md
+++ b/README.md
@@ -84,8 +84,10 @@ You can also easily Deploy to Heroku and the like, just be sure to edit `YOUR_UR
     "REGEX_IGNORED_CHAT": "packets too frequently", /* What to ignore, you can put any regex for swear words for example and it will  be ignored */
     "DEBUG": false, /* Dev debugging */
 
-    "SERVER_NAME": "Shulker", /* The username used when displaying any server information in chat, e.g., Server - Shulker : Server message here*/
     "SERVER_IMAGE": "", /* Image for the server when sending such messages (if enabled below). Only for WebHooks. */
+    "SERVER_NAME": "Shulker", /* The username used when displaying any server information in chat, e.g., Shulker - Server : Server message here*/
+    "PLAYERCOUNT_IN_SERVERNAME": false, /* Will add the number of players currently in the server to any server messages e.g., Shulker - Server (1 online) : Server message here*/
+    "PLAYERCOUNT": 0, /* For most cases you can leave this at 0 but if you are starting Shulker when there are already players in the server set this to the current number of players online*/
     "SHOW_PLAYER_CONN_STAT": false, /* Shows player connection status in chat, e.g., Server - Shulker : TheMachine joined the game */
     "SHOW_PLAYER_ADVANCEMENT": false, /* Shows when players earn advancements in chat, e.g., Server - Shulker : TheMachine has made the advacement [MEME - Machine] */
     "SHOW_PLAYER_DEATH": false, /* Shows when players die in chat, e.g., Server - Shulker : TheMachine was blown up by creeper */

--- a/config.json
+++ b/config.json
@@ -30,8 +30,10 @@
     "REGEX_IGNORED_CHAT": "packets too frequently",
     "DEBUG": false,
 
-    "SERVER_NAME": "Shulker",
     "SERVER_IMAGE": "",
+    "SERVER_NAME": "Shulker",
+    "PLAYERCOUNT_IN_SERVERNAME": false,
+    "PLAYERCOUNT": 0,
     "SHOW_PLAYER_CONN_STAT": false,
     "SHOW_PLAYER_ADVANCEMENT": false,
     "SHOW_PLAYER_DEATH": false,

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "axios": "^0.19.2",
     "discord.js": "^11.5.1",
     "emoji-strip": "^1.0.1",
+    "escape-string-regexp": "^4.0.0",
     "express": "^4.17.1",
     "tail": "^2.0.3"
   },

--- a/src/Config.ts
+++ b/src/Config.ts
@@ -33,8 +33,10 @@ export interface Config {
   REGEX_IGNORED_CHAT: string
   DEBUG: boolean
 
-  SERVER_NAME: string
   SERVER_IMAGE: string
+  SERVER_NAME: string
+  PLAYERCOUNT_IN_SERVERNAME: boolean
+  PLAYERCOUNT: number
   SHOW_PLAYER_CONN_STAT: boolean
   SHOW_PLAYER_ADVANCEMENT: boolean
   SHOW_PLAYER_DEATH: boolean

--- a/src/Discord.ts
+++ b/src/Discord.ts
@@ -1,5 +1,5 @@
 import {Client, Message, Snowflake, TextChannel} from 'discord.js'
-
+import escapeStringRegexp from 'escape-string-regexp'
 import emojiStrip from 'emoji-strip'
 import axios from 'axios'
 
@@ -177,7 +177,8 @@ class Discord {
     message = this.replaceDiscordMentions(message)
 
     let avatarURL
-    if (username === this.config.SERVER_NAME + ' - Server') { // use avatar for the server
+    const serverNameRegex = new RegExp(escapeStringRegexp(`${this.config.SERVER_NAME} - Server`)+`.*`);
+    if (username.match(serverNameRegex)) { // use avatar for the server
       avatarURL = this.config.SERVER_IMAGE || 'https://minotar.net/helm/Steve/256.png'
     } else { // use avatar for player
       avatarURL = `https://minotar.net/helm/${username}/256.png`

--- a/src/MinecraftHandler.ts
+++ b/src/MinecraftHandler.ts
@@ -80,21 +80,31 @@ class MinecraftHandler {
         console.log('[DEBUG] Text: ' + matches[2])
       }
       return { username, message }
-    } else if ( this.config.SHOW_PLAYER_CONN_STAT && ( logLine.includes('left the game') || logLine.includes('joined the game'))) {
+    } else if (logLine.includes('left the game') || logLine.includes('joined the game')) {
       // handle disconnection etc.
       if (this.config.DEBUG){
         console.log(`[DEBUG]: A player's connection status changed`)
       }
 
-      if ( logLine.includes('joined the game')){
-        this.config.PLAYERCOUNT += 1 
+      // Only keep track of player count if enabled
+      if (this.config.PLAYERCOUNT_IN_SERVERNAME){
+        if ( logLine.includes('joined the game')){
+          this.config.PLAYERCOUNT += 1 
+        } else {
+          if (this.config.PLAYERCOUNT != 0){
+            this.config.PLAYERCOUNT -= 1
+          }  
+        }
+        serverUsername = serverUsername.replace(/- [0-9]{1,10} online/, `- ${this.config.PLAYERCOUNT} online`)
+      }
+      
+      // Only send to discord if SHOW_PLAYER_CONN_STAT is enabled otherwise dont send anything
+      if (this.config.SHOW_PLAYER_CONN_STAT){
+        return { username: serverUsername, message: logLine }
       } else {
-        if (this.config.PLAYERCOUNT != 0){
-          this.config.PLAYERCOUNT -= 1
-        }  
+        return null
       }
 
-      return { username: serverUsername.replace(/- [0-9]{1,10} online/, `- ${this.config.PLAYERCOUNT} online`), message: logLine }
     } else if (this.config.SHOW_PLAYER_ADVANCEMENT && logLine.includes('made the advancement')) {
       // handle advancements
       if (this.config.DEBUG){

--- a/src/MinecraftHandler.ts
+++ b/src/MinecraftHandler.ts
@@ -53,8 +53,12 @@ class MinecraftHandler {
 
     const logLine = logLineData[1]
 
-    // the username used for server messages
-    const serverUsername = `${this.config.SERVER_NAME} - Server`
+    // the username used for server messages 
+    // DO NOT REMOVE "- Server" or you will break the regex used in Discord.ts to select the correct avatarURL 
+    var serverUsername = `${this.config.SERVER_NAME} - Server`
+    if (this.config.PLAYERCOUNT_IN_SERVERNAME) {
+      serverUsername += ` - ${this.config.PLAYERCOUNT} online`
+    }
 
     if (logLine.startsWith('<')) {
       if (this.config.DEBUG){
@@ -76,18 +80,21 @@ class MinecraftHandler {
         console.log('[DEBUG] Text: ' + matches[2])
       }
       return { username, message }
-    } else if (
-      this.config.SHOW_PLAYER_CONN_STAT && (
-        logLine.includes('left the game') ||
-        logLine.includes('joined the game')
-      )
-    ) {
+    } else if ( this.config.SHOW_PLAYER_CONN_STAT && ( logLine.includes('left the game') || logLine.includes('joined the game'))) {
       // handle disconnection etc.
       if (this.config.DEBUG){
         console.log(`[DEBUG]: A player's connection status changed`)
       }
 
-      return { username: serverUsername, message: logLine }
+      if ( logLine.includes('joined the game')){
+        this.config.PLAYERCOUNT += 1 
+      } else {
+        if (this.config.PLAYERCOUNT != 0){
+          this.config.PLAYERCOUNT -= 1
+        }  
+      }
+
+      return { username: serverUsername.replace(/- [0-9]{1,10} online/, `- ${this.config.PLAYERCOUNT} online`), message: logLine }
     } else if (this.config.SHOW_PLAYER_ADVANCEMENT && logLine.includes('made the advancement')) {
       // handle advancements
       if (this.config.DEBUG){

--- a/yarn.lock
+++ b/yarn.lock
@@ -462,6 +462,11 @@ escape-string-regexp@^1.0.5:
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
   integrity sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
 
+escape-string-regexp@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz#14ba83a5d373e3d311e5afca29cf5bfad965bf34"
+  integrity sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==
+
 eslint-config-standard-jsx@8.1.0:
   version "8.1.0"
   resolved "https://registry.yarnpkg.com/eslint-config-standard-jsx/-/eslint-config-standard-jsx-8.1.0.tgz#314c62a0e6f51f75547f89aade059bec140edfc7"


### PR DESCRIPTION
- Added ability to append the number of users currently in the server to the server username.
![image](https://user-images.githubusercontent.com/31785616/82743789-dc61c580-9d24-11ea-964b-9da9fcf073ea.png)

- Online player count is still tracked and show correctly on other server notifications when SHOW_PLAYER_CONN_STAT is set to false as long as PLAYERCOUNT_IN_SERVERNAME is enabled. This is used for the circumstances where player  count is desired to be part of the server username but join and leave notifications are not.   

- Added escape-string-regexp library to help sanitize variables. Used in the function that selects correct Avatar URL. This also improves the original way of detecting whether the username was the server name because as long as the username has "ServerName - Server" somewhere in it, it picks the server Avatar URL.  Allowing future items to be appended on the server username without affecting detection. 