### PR TITLE
Add option to output server status into discord

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ You can also easily Deploy to Heroku and the like, just be sure to edit `YOUR_UR
 
     "SERVER_NAME": "Shulker", /* The username used when displaying any server information in chat, e.g., Server - Shulker : Server message here*/
     "SERVER_IMAGE": "", /* Image for the server when sending such messages (if enabled below). Only for WebHooks. */
+    "SHOW_SERVER_STATUS: false, /* Shows when the server turns on and off e.g., Server - Shulker : Server is online */
     "SHOW_PLAYER_CONN_STAT": false, /* Shows player connection status in chat, e.g., Server - Shulker : TheMachine joined the game */
     "SHOW_PLAYER_ADVANCEMENT": false, /* Shows when players earn advancements in chat, e.g., Server - Shulker : TheMachine has made the advacement [MEME - Machine] */
     "SHOW_PLAYER_DEATH": false, /* Shows when players die in chat, e.g., Server - Shulker : TheMachine was blown up by creeper */

--- a/config.json
+++ b/config.json
@@ -34,6 +34,7 @@
 
     "SERVER_NAME": "Shulker",
     "SERVER_IMAGE": "",
+    "SHOW_SERVER_STATUS": false,
     "SHOW_PLAYER_CONN_STAT": false,
     "SHOW_PLAYER_ADVANCEMENT": false,
     "SHOW_PLAYER_DEATH": false,

--- a/src/Config.ts
+++ b/src/Config.ts
@@ -37,6 +37,7 @@ export interface Config {
 
   SERVER_NAME: string
   SERVER_IMAGE: string
+  SHOW_SERVER_STATUS: boolean
   SHOW_PLAYER_CONN_STAT: boolean
   SHOW_PLAYER_ADVANCEMENT: boolean
   SHOW_PLAYER_DEATH: boolean

--- a/src/MinecraftHandler.ts
+++ b/src/MinecraftHandler.ts
@@ -88,6 +88,16 @@ class MinecraftHandler {
       }
 
       return { username: serverUsername, message: logLine }
+    } else if (this.config.SHOW_SERVER_STATUS && (logLine.includes('Starting minecraft server'))) {
+        if (this.config.DEBUG) {
+            console.log('[DEBUG]: Server has started')
+        }
+        return { username: serverUsername, message: "Server is online" }
+    } else if (this.config.SHOW_SERVER_STATUS && (logLine.includes('Stopping the server'))) {
+        if (this.config.DEBUG) {
+            console.log('[DEBUG]: Server has stopped')
+        }
+        return { username: serverUsername, message: "Server is offline" }
     } else if (this.config.SHOW_PLAYER_ADVANCEMENT && logLine.includes('made the advancement')) {
       // handle advancements
       if (this.config.DEBUG){


### PR DESCRIPTION
### Changes
Add option SHOW_SERVER_STATUS to the configuration file, when set to true it will output when the server turns on and off. I thought this would be useful as I am hosting my server on a pricy EC2 server and I would like to save costs when no one is online.

### Testing
Tested on my personal server:
![image](https://user-images.githubusercontent.com/7217738/96615844-d2da8a80-12cf-11eb-9986-b9c444f5813b.png)

Signed-off-by: elveskevtar <kevtar@gmail.com>