### PR TITLE
Fix death message false positives

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ You can also easily Deploy to Heroku and the like, just be sure to edit `YOUR_UR
     "WEBHOOK": "/minecraft/hook", /* Web hook, where to send the log to */
     "REGEX_SERVER_PREFIX": "\\[Server thread/INFO\\]:", /* What the lines of the log should start with */
     "REGEX_MATCH_CHAT_MC": "^<([^>]*)> (.*)", /* What to match for chat (best to leave as default) */
+    "REGEX_DEATH_MESSAGE": "^[\w_]+ (died|...)", /* What to match for death messages (best leave this default too) */
     "REGEX_IGNORED_CHAT": "packets too frequently", /* What to ignore, you can put any regex for swear words for example and it will  be ignored */
     "DEBUG": false, /* Dev debugging */
 
@@ -92,8 +93,7 @@ You can also easily Deploy to Heroku and the like, just be sure to edit `YOUR_UR
     "SHOW_PLAYER_CONN_STAT": false, /* Shows player connection status in chat, e.g., Server - Shulker : TheMachine joined the game */
     "SHOW_PLAYER_ADVANCEMENT": false, /* Shows when players earn advancements in chat, e.g., Server - Shulker : TheMachine has made the advacement [MEME - Machine] */
     "SHOW_PLAYER_DEATH": false, /* Shows when players die in chat, e.g., Server - Shulker : TheMachine was blown up by creeper */
-    "SHOW_PLAYER_ME": false, /* Shows when players use the /me command, e.g. **destruc7i0n** says hello */
-    "DEATH_KEY_WORDS": ["shot", "fell", "etc".] /* Key words to look for when trying to identify a death message. (As of 3/11/2019 this list is up to date) */
+    "SHOW_PLAYER_ME": false /* Shows when players use the /me command, e.g. **destruc7i0n** says hello */
 }
 ```
 

--- a/config.json
+++ b/config.json
@@ -29,6 +29,7 @@
     "WEBHOOK": "/minecraft/hook",
     "REGEX_SERVER_PREFIX": "\\[Server thread/INFO\\]:",
     "REGEX_MATCH_CHAT_MC": "^<([^>]*)> (.*)",
+    "REGEX_DEATH_MESSAGE": "^[\\w_]+ (died|drowned|blew up|fell|burned|froze|starved|suffocated|withered|walked into a cactus|experienced kinetic energy|discovered the floor was lava|tried to swim in lava|hit the ground|didn't want to live|went (up in flames|off with a bang)|walked into (fire|danger)|was (killed|shot|slain|pummeled|pricked|blown up|impaled|squashed|squished|skewered|poked|roasted|burnt|frozen|struck by lightning|fireballed|stung|doomed))",
     "REGEX_IGNORED_CHAT": "packets too frequently",
     "DEBUG": false,
 
@@ -38,7 +39,6 @@
     "SHOW_PLAYER_CONN_STAT": false,
     "SHOW_PLAYER_ADVANCEMENT": false,
     "SHOW_PLAYER_DEATH": false,
-    "SHOW_PLAYER_ME": false,
-    "DEATH_KEY_WORDS": ["shot", "fell", "death", "died", "doomed", "pummeled", "removed", "didn't want", "withered", "squashed", "flames", "burnt", "walked into", "bang", "roasted", "squished", "drowned", "killed", "slain", "blown", "blew", "suffocated", "struck", "lava", "impaled", "speared", "fireballed", "finished", "kinetic"]
+    "SHOW_PLAYER_ME": false
 }
 

--- a/config.json
+++ b/config.json
@@ -29,7 +29,7 @@
     "WEBHOOK": "/minecraft/hook",
     "REGEX_SERVER_PREFIX": "\\[Server thread/INFO\\]:",
     "REGEX_MATCH_CHAT_MC": "^<([^>]*)> (.*)",
-    "REGEX_DEATH_MESSAGE": "^[\\w_]+ (died|drowned|blew up|fell|burned|froze|starved|suffocated|withered|walked into a cactus|experienced kinetic energy|discovered the floor was lava|tried to swim in lava|hit the ground|didn't want to live|went (up in flames|off with a bang)|walked into (fire|danger)|was (killed|shot|slain|pummeled|pricked|blown up|impaled|squashed|squished|skewered|poked|roasted|burnt|frozen|struck by lightning|fireballed|stung|doomed))",
+    "REGEX_DEATH_MESSAGE": "^[\\w_]+ (died|drowned|blew up|fell|burned|froze|starved|suffocated|withered|walked into a cactus|experienced kinetic energy|discovered (the )?floor was lava|tried to swim in lava|hit the ground|didn't want to live|went (up in flames|off with a bang)|walked into (fire|danger)|was (killed|shot|slain|pummeled|pricked|blown up|impaled|squashed|squished|skewered|poked|roasted|burnt|frozen|struck by lightning|fireballed|stung|doomed))",
     "REGEX_IGNORED_CHAT": "packets too frequently",
     "DEBUG": false,
 

--- a/src/Config.ts
+++ b/src/Config.ts
@@ -32,6 +32,7 @@ export interface Config {
   WEBHOOK: string
   REGEX_SERVER_PREFIX: string
   REGEX_MATCH_CHAT_MC: string
+  REGEX_DEATH_MESSAGE: string
   REGEX_IGNORED_CHAT: string
   DEBUG: boolean
 
@@ -42,5 +43,4 @@ export interface Config {
   SHOW_PLAYER_ADVANCEMENT: boolean
   SHOW_PLAYER_DEATH: boolean
   SHOW_PLAYER_ME: boolean
-  DEATH_KEY_WORDS: string[]
 }

--- a/src/MinecraftHandler.ts
+++ b/src/MinecraftHandler.ts
@@ -113,15 +113,14 @@ class MinecraftHandler {
         return { username: serverUsername, message: `**${username}** ${rest}` }
       }
     } else if (this.config.SHOW_PLAYER_DEATH) {
-      for (let word of this.config.DEATH_KEY_WORDS){
-        if (data.includes(word)){
-          if (this.config.DEBUG) {
-            console.log(
-              `[DEBUG] A player died. Matched key word "${word}"`
-            )
-          }
-          return { username: serverUsername, message: logLine }
+      const death_msg_re = new RegExp(this.config.REGEX_DEATH_MESSAGE)
+      const death_msg_match = logLine.match(death_msg_re)
+
+      if (death_msg_match) {
+        if (this.config.DEBUG) {
+          console.log(`[DEBUG] A player died. Matched on "${death_msg_match[1]}"`)
         }
+        return { username: serverUsername, message: logLine }
       }
     }
 

--- a/src/Shulker.ts
+++ b/src/Shulker.ts
@@ -8,6 +8,8 @@ class Shulker {
   discordClient: DiscordClient
   handler: Handler
 
+  readonly deprecatedConfigs: string[] = ['DEATH_KEY_WORDS'];
+
   constructor() {
   }
 
@@ -18,6 +20,12 @@ class Shulker {
     if (!this.config) {
       console.log('[ERROR] Could not load config file!')
       return false
+    }
+
+    for (let option of this.deprecatedConfigs) {
+      if (this.config.hasOwnProperty(option)) {
+        console.log('[WARN] Using deprecated config option ' + option + '. Check README.md for current options.')
+      }
     }
 
     if (this.config.USE_WEBHOOKS) {


### PR DESCRIPTION
This fixes issue #70 by replacing the death keyword config option with a death message regex config option.