### PR TITLE
Added basic systemd script

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,34 @@ npm run build
 npm run start
 ```
 
+OPTIONAL: Install systemd script to run shulker as a background service. 
+
+Edit shulker.service.example file to match your environment variables (note .service files are case-sensitive):
+
+```
+[Service]
+ExecStart=/usr/bin/npm start
+Restart=always
+User=USER **Replace with user that will run the service**
+Group=GROUP **Replace with user's group**
+Environment=PATH=/usr/bin:/usr/local/bin
+Environment=NODE_ENV=production
+WorkingDirectory=PATH **Replace with path to shulker directory**
+```
+
+Rename to shulker.service and copy to /etc/systemd/system/ 
+
+Next, reload the service files, enable the service and start it:
+
+```sh
+systemctl daemon-reload
+systemctl enable shulker
+systemctl start shulker
+```
+
+Shulker will now start in the background during boot
+
+
 ### Configuration
 Details on the `config.json` file.
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Edit shulker.service.example file to match your environment variables (note .ser
 
 ```
 [Service]
+ExecStartPre=/bin/sh -c 'until host example.com; do sleep 1; done'
 ExecStart=/usr/bin/npm start
 Restart=always
 User=USER **Replace with user that will run the service**

--- a/shulker.service.example
+++ b/shulker.service.example
@@ -1,0 +1,21 @@
+## CorQB - Oct 25, 2025
+
+## /etc/systemd/system/shulker.service
+## Use this file to start shulker automatically as a service
+## Edit commented sections below to your specific case
+
+[Unit]
+Description=Shulker - A Minecraft Server Discord Listener
+After=network.target
+
+[Service]
+ExecStart=/usr/bin/npm start
+Restart=always
+User= ## User that will run the service
+Group= ## User's group
+Environment=PATH=/usr/bin:/usr/local/bin
+Environment=NODE_ENV=production
+WorkingDirectory= ## Path to shulker directory
+
+[Install]
+WantedBy=multi-user.target

--- a/shulker.service.example
+++ b/shulker.service.example
@@ -7,8 +7,10 @@
 [Unit]
 Description=Shulker - A Minecraft Server Discord Listener
 After=network.target
+Wants=network.target
 
 [Service]
+ExecStartPre=/bin/sh -c 'until host example.com; do sleep 1; done'
 ExecStart=/usr/bin/npm start
 Restart=always
 User= ## User that will run the service


### PR DESCRIPTION
Added shulker.service.example and instructions in the readme for setting up shulker to run as a systemd service during boot process.

- Fixed service failing start on boot; now checks for successful connection to discord before attempting to start shulker

